### PR TITLE
Modified mget and mget_by_index. If the request body json contains 'd…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -203,6 +203,12 @@ class SearchAPI:
         logger.info("======mget with no index provided======")
         logger.info("default_index: " + self.DEFAULT_INDEX_WITHOUT_PREFIX)
 
+        if 'docs' in request.get_json():
+            for item in request.get_json()['docs']:
+                if '_index' in item:
+                    bad_request_error(
+                        "Index may not be specified in request body. To target a specific index, use /<index_without_prefix>/mget")
+
         # Determine the target real index in Elasticsearch to be searched against
         # Use the DEFAULT_INDEX_WITHOUT_PREFIX since /search doesn't take any index
         target_index = self.get_target_index(request, self.DEFAULT_INDEX_WITHOUT_PREFIX)
@@ -224,6 +230,11 @@ class SearchAPI:
 
         logger.info("======requested index_without_prefix======")
         logger.info(index_without_prefix)
+
+        if 'docs' in request.get_json():
+            for item in request.get_json()['docs']:
+                if '_index' in item:
+                    bad_request_error("Index may not be specified in request body. To target a specific index, use /<index_without_prefix>/mget")
 
         # Determine the target real index in Elasticsearch to be searched against
         target_index = self.get_target_index(request, index_without_prefix)

--- a/src/app.py
+++ b/src/app.py
@@ -207,7 +207,7 @@ class SearchAPI:
             for item in request.get_json()['docs']:
                 if '_index' in item:
                     bad_request_error(
-                        "Index may not be specified in request body. To target a specific index, use /<index_without_prefix>/mget")
+                        "Index may not be specified in request body. To target a specific index, use /<index>/mget")
 
         # Determine the target real index in Elasticsearch to be searched against
         # Use the DEFAULT_INDEX_WITHOUT_PREFIX since /search doesn't take any index
@@ -234,7 +234,7 @@ class SearchAPI:
         if 'docs' in request.get_json():
             for item in request.get_json()['docs']:
                 if '_index' in item:
-                    bad_request_error("Index may not be specified in request body. To target a specific index, use /<index_without_prefix>/mget")
+                    bad_request_error("Index may not be specified in request body. To target a specific index, use /<index>/mgett")
 
         # Determine the target real index in Elasticsearch to be searched against
         target_index = self.get_target_index(request, index_without_prefix)


### PR DESCRIPTION
Modified mget and mget_by_index. If the request body json contains 'docs', and 'docs' contains '_index', an error is raised prompting the specify the chosen index with a string parameter in mget_by_index.