### PR TITLE
Remove put and post without composite index

### DIFF
--- a/src/indexer.py
+++ b/src/indexer.py
@@ -30,7 +30,7 @@ class Indexer:
         self.eswriter.delete_document(index_name, entity_id)
 
     def delete_fieldmatch_document(self, index_name, field_name=None, field_value=None):
-        self.eswriter.delete_fieldmatch_document(index_name, field_name, field_value)
+        return self.eswriter.delete_fieldmatch_document(index_name, field_name, field_value)
 
     def delete_index(self, index_name):
         self.eswriter.delete_index(index_name)

--- a/src/libs/es_writer.py
+++ b/src/libs/es_writer.py
@@ -73,13 +73,17 @@ class ESWriter:
             rspn = requests.post(post_url, headers=headers, data=jsonQuery)
             if rspn.ok:
                 logger.info(msgSuccess)
+                return msgSuccess, 200
             else:
                 logger.error(msgFailure)
                 logger.error(f"Error Message: {rspn.text}")
+                return msgFailure, 400
         except Exception as e:
             msgUnexpected = "Exception encountered during executing ESWriter.delete_fieldmatch_document() with field_name='{field_name}', field_value='{field_value}', index_name='{index_name}'"
             # Log the full stack trace, prepend a line with our message
             logger.exception(msgUnexpected)
+            return msgUnexpected, 400
+
     def write_or_update_document(self, index_name='index', type_='_doc', doc='', uuid=''):
         try:
             headers = {'Content-Type': 'application/json'}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,4 +10,4 @@ PyYAML>=5.3.1
 # Use the branch name of commons from github for testing new changes made in commons from different branch
 # Default is main branch
 #git+https://github.com/hubmapconsortium/commons.git@main#egg=hubmap-commons
-hubmap-commons==2.1.3
+hubmap-commons==2.1.4


### PR DESCRIPTION
Remove acceptance of OpenSearch index names as parameters to endpoints supporting files-api.  Work with composite index names from YAML configuration and status of Datasets to determine appropriate OpenSearch index for create, update, and delete operations. Issue search-api#608