### PR TITLE
Karlburke/indexing efficiencies round2

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1257,7 +1257,7 @@ class SearchAPI:
 
     def init_translator(self, token):
         if self.ubkg_instance is None:
-            return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token, self.ONTOLOGY_API_BASE_URL)
+            return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token)
         return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token, self.ubkg_instance)
 
     # Get a list of filtered Elasticsearch indices to expose to end users without the prefix

--- a/src/app.py
+++ b/src/app.py
@@ -1257,7 +1257,7 @@ class SearchAPI:
 
     def init_translator(self, token):
         if self.ubkg_instance is None:
-            return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token)
+            return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token, self.ONTOLOGY_API_BASE_URL)
         return self.translator_module.Translator(self.INDICES, self.APP_CLIENT_ID, self.APP_CLIENT_SECRET, token, self.ubkg_instance)
 
     # Get a list of filtered Elasticsearch indices to expose to end users without the prefix

--- a/src/translator/tranlation_helper_functions.py
+++ b/src/translator/tranlation_helper_functions.py
@@ -51,35 +51,6 @@ def get_all_reindex_enabled_indice_names(all_indices):
 
     return all_names
 
-
-def get_type_description(type_code, type_yaml_file_name):
-    filename = 'search-schema/data/definitions/enums/' + type_yaml_file_name + '.yaml'
-    type_yaml_file = Path(
-        __file__).absolute().parent.parent.parent.parent / filename
-
-    logger.debug(f"========type_code: {type_code}")
-
-    with open(type_yaml_file) as file:
-        definition_dict = yaml.safe_load(file)
-
-        logger.info(f"Definition yaml file {type_yaml_file} loaded successfully")
-
-        if type_code in definition_dict:
-            definition_desc = definition_dict[type_code]['description']
-        else:
-            # Return the error message as description
-            msg = f"Missing definition key {type_code} in {type_yaml_file}"
-
-            logger.error(msg)
-
-            # Use triple {{{}}}
-            definition_desc = f"{{{type_code}}}"
-
-        logger.debug(f"========definition_desc: {definition_desc}")
-
-        return definition_desc
-
-
 def remove_specific_key_entry(obj, key_to_remove=None):
     if type(obj) == dict:
         if key_to_remove in obj.keys():


### PR DESCRIPTION
Clean up remaining ontology-api references now that `display_subtype` is calculated in `entity-api` rather than HuBMAP's `search-api`.